### PR TITLE
add navigation from category title to quiz page

### DIFF
--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -13,7 +13,7 @@ export const routes: Routes = [
     ),
   },
   {
-    path: 'quiz',
+    path: 'quiz/:id',
     loadComponent: () => import('./pages/quiz/quiz.component').then(c => c.QuizComponent),
   },
   {

--- a/src/app/pages/catalog/catalog.component.html
+++ b/src/app/pages/catalog/catalog.component.html
@@ -25,6 +25,8 @@
         <quiz-quiz-card [quizCategory]="category" />
       }
     </div>
-    <quiz-ui-button class="m-4" route="/quiz"> I'm lucky </quiz-ui-button>
+    <quiz-ui-button class="m-4" ` (buttonClick)="goToRandomQuiz()">
+      I'm lucky
+    </quiz-ui-button>
   }
 </div>

--- a/src/app/pages/catalog/catalog.component.ts
+++ b/src/app/pages/catalog/catalog.component.ts
@@ -10,6 +10,8 @@ import { isLoading$ } from '../../store/categories.store';
 import { ErrorHandlerService } from '../../core/services/error-handler.service';
 import { UiErrorNotificationComponent } from '../../shared/ui-kit/ui-error-notification/ui-error-notification.component';
 import { QuizCategory } from '../../shared/models/quiz-category.model';
+import { Router } from '@angular/router';
+import { RandomizationService } from '../../core/services/randomization.service';
 
 @Component({
   selector: 'quiz-catalog',
@@ -25,12 +27,15 @@ import { QuizCategory } from '../../shared/models/quiz-category.model';
 })
 export class CatalogComponent implements OnInit {
   private readonly categoriesService = inject(CategoriesService);
+  private readonly randomizationService = inject(RandomizationService);
   private readonly categoriesStoreService = inject(CategoriesStoreService);
   private readonly errorHandlerService = inject(ErrorHandlerService);
+  private readonly router = inject(Router);
 
   categories$!: Observable<QuizCategory[]>;
   isLoading$ = isLoading$;
   errorMessage$ = this.errorHandlerService.getErrorMessage$();
+  randomCategoryId!: number;
 
   ngOnInit(): void {
     this.categoriesService.getRandomCategories().subscribe();
@@ -40,5 +45,15 @@ export class CatalogComponent implements OnInit {
 
   simulateError(): void {
     this.errorHandlerService.setError();
+  }
+
+  goToRandomQuiz(): void {
+    this.categories$.subscribe((categories) => {
+      const randomIndex = this.randomizationService.getRandomInt(
+        0,
+        categories.length,
+      );
+      this.router.navigate([ '/quiz', categories[randomIndex].id ]);
+    });
   }
 }

--- a/src/app/pages/quiz/quiz.component.html
+++ b/src/app/pages/quiz/quiz.component.html
@@ -1,1 +1,1 @@
-<p class="bg-gray-600 text-center text-7xl">quiz page</p>
+<p class="bg-gray-600 text-center text-7xl">quiz id: {{ quizId }}</p>

--- a/src/app/pages/quiz/quiz.component.ts
+++ b/src/app/pages/quiz/quiz.component.ts
@@ -1,4 +1,5 @@
-import { Component } from '@angular/core';
+import { Component, inject } from '@angular/core';
+import { ActivatedRoute } from '@angular/router';
 
 @Component({
   selector: 'quiz-quiz',
@@ -6,4 +7,11 @@ import { Component } from '@angular/core';
   imports: [],
   templateUrl: './quiz.component.html',
 })
-export class QuizComponent {}
+export class QuizComponent {
+  quizId!: string;
+  route = inject(ActivatedRoute);
+
+  ngOnInit(): void {
+    this.quizId = this.route.snapshot.paramMap.get('id')!;
+  }
+}

--- a/src/app/shared/ui-kit/ui-quiz-card/ui-quiz-card.component.html
+++ b/src/app/shared/ui-kit/ui-quiz-card/ui-quiz-card.component.html
@@ -5,7 +5,12 @@
     </p>
     <img class="h-12 w-12" [src]="styles.avatarSrc" alt="category icon" />
   </div>
-  <h3 class="text-2xl font-bold {{ styles.headerColor }}">
+  <h3
+    class="text-2xl cursor-pointer md:hover:underline font-bold {{
+      styles.headerColor
+    }}"
+    [routerLink]="['/quiz', quizCategory()?.id]"
+  >
     {{ quizCategory()?.name }}
   </h3>
 </div>

--- a/src/app/shared/ui-kit/ui-quiz-card/ui-quiz-card.component.ts
+++ b/src/app/shared/ui-kit/ui-quiz-card/ui-quiz-card.component.ts
@@ -4,10 +4,12 @@ import { QuizCardColors } from '../../enums/quiz-card-colors.enums';
 import { QuizCardStyle } from './ui-quiz-card.types';
 import { QuizCategory } from '../../models/quiz-category.model';
 import { DEFAULT_CARD_COLOR } from './ui-quiz-card.constants';
+import { RouterLink } from '@angular/router';
 
 @Component({
   selector: 'quiz-quiz-card',
   standalone: true,
+  imports: [RouterLink],
   templateUrl: './ui-quiz-card.component.html',
 })
 export class UiQuizCardComponent {


### PR DESCRIPTION
Links
[Trello ticket](https://trello.com/c/wFp0Cnav/9-implement-quizzes-catalog-page)

Problem
The category title doesn't have navigation to the quiz page
The "I'm lucky" button doesn't have any functionality
Solution
Add a routerLink for each category title
Implement functionality for the "I'm lucky" button
Add a pointer cursor and hover effect for the category title in the quiz card
