### PR TITLE
Fix/fix demo3 style comments

### DIFF
--- a/src/app/pages/catalog/catalog.component.html
+++ b/src/app/pages/catalog/catalog.component.html
@@ -1,7 +1,3 @@
-<button (click)="simulateError()" class="rounded bg-red-500 p-2 text-white">
-  Simulate Error
-</button>
-
 <div class="flex flex-col flex-wrap items-center">
   <h1 class="mt-20 text-center">
     <span class="p-4 text-4xl font-semibold md:text-6xl-plus">Choose your</span>
@@ -15,7 +11,8 @@
 
   @if (errorMessage$ | async; as errorMessage) {
     <quiz-ui-error-notification
-      [errorMessage]="errorMessage" (tryAgainButtonClick)="reloadCategories()"
+      [errorMessage]="errorMessage"
+      (tryAgainButtonClick)="reloadCategories()"
     ></quiz-ui-error-notification>
   } @else if (isLoading$ | async) {
     <quiz-ui-spinner></quiz-ui-spinner>

--- a/src/app/pages/catalog/catalog.component.ts
+++ b/src/app/pages/catalog/catalog.component.ts
@@ -40,10 +40,6 @@ export class CatalogComponent implements OnInit {
     this.loadCategories();
   }
 
-  simulateError(): void {
-    this.errorHandlerService.setError();
-  }
-
   goToRandomQuiz(): void {
     this.categories$.pipe(take(1)).subscribe((categories) => {
       const randomIndex = this.randomizationService.getRandomInt(

--- a/src/app/pages/main/main.component.html
+++ b/src/app/pages/main/main.component.html
@@ -9,7 +9,5 @@
     </span>
   </div>
 
-  <quiz-ui-button route="/catalog" (buttonClick)="handleButtonClick()">
-    Let's play
-  </quiz-ui-button>
+  <quiz-ui-button route="/catalog"> Let's play </quiz-ui-button>
 </div>

--- a/src/app/pages/main/main.component.ts
+++ b/src/app/pages/main/main.component.ts
@@ -7,8 +7,4 @@ import { UiButtonComponent } from '../../shared/ui-kit/ui-button/ui-button.compo
   imports: [UiButtonComponent],
   templateUrl: './main.component.html',
 })
-export class MainComponent {
-  handleButtonClick() {
-    alert('opening catalog page');
-  }
-}
+export class MainComponent {}

--- a/src/app/shared/ui-kit/ui-header/ui-header.component.html
+++ b/src/app/shared/ui-kit/ui-header/ui-header.component.html
@@ -12,9 +12,12 @@
     <ul class="flex space-x-6">
       @for (item of navItems; track $index) {
         <li class="duration-100 ease-in md:hover:scale-125">
-          <a [routerLink]="item.link" routerLinkActive="font-semibold">{{
-            item.label
-          }}</a>
+          <a
+            [routerLink]="item.link"
+            routerLinkActive="font-semibold"
+            [routerLinkActiveOptions]="{ exact: true }"
+            >{{ item.label }}</a
+          >
         </li>
       }
     </ul>

--- a/src/app/shared/ui-kit/ui-question-card/ui-question-card.component.html
+++ b/src/app/shared/ui-kit/ui-question-card/ui-question-card.component.html
@@ -37,43 +37,48 @@
       </form>
     </div>
 
-    <div class="mt-5 flex items-center justify-between">
-      <quiz-ui-button
-        class="text-shade"
-        [variant]="'ghost'"
-        [disabled]="isFirstQuestion()"
-        (buttonClick)="previousQuestion()"
-        ><svg-icon
-          [src]="'assets/icons/chevron-left.svg'"
-          [svgClass]="'h-6 w-6 text-shade'"
-          [applyClass]="true"
-        ></svg-icon>
-        <span class="md:hidden">Prev</span>
-        <span class="hidden md:inline">Prev question</span></quiz-ui-button
-      >
-      @if (isLastQuestion()) {
+    <div class="my-5 flex items-center justify-between">
+      <div>
+        @if (!isFirstQuestion()) {
+          <quiz-ui-button
+            [variant]="'accent'"
+            (buttonClick)="previousQuestion()"
+            ><svg-icon
+              [src]="'assets/icons/chevron-left.svg'"
+              [svgClass]="'h-6 w-6 text-shade'"
+              [applyClass]="true"
+            ></svg-icon>
+            <span class="md:hidden">Prev</span>
+            <span class="hidden md:inline">Prev question</span></quiz-ui-button
+          >
+        }
+      </div>
+
+      <div class="flex">
         <quiz-ui-button
           [variant]="'accent'"
-          [disabled]="!radioButtonControl.valid"
-          (buttonClick)="finishQuiz()"
+          (buttonClick)="isLastQuestion() ? finishQuiz() : nextQuestion()"
         >
-          Finish the quiz</quiz-ui-button
-        >
-      } @else {
-        <quiz-ui-button
-          [variant]="'accent'"
-          [disabled]="!radioButtonControl.valid"
-          (buttonClick)="nextQuestion()"
-        >
-          <span class="md:hidden">Next</span>
-          <span class="hidden md:inline">Next question</span>
+          <span class="md:hidden">{{
+            isLastQuestion() ? 'Finish' : 'Next'
+          }}</span>
+          <span class="hidden md:inline">
+            {{ isLastQuestion() ? 'Finish the quiz' : 'Next question' }}</span
+          >
           <svg-icon
             [src]="'assets/icons/chevron-left.svg'"
             [svgClass]="'h-6 w-6 text-bright transform rotate-180'"
             [applyClass]="true"
           ></svg-icon
         ></quiz-ui-button>
-      }
+        @if (isMessageVisible) {
+          <span
+            class="absolute mt-10 max-w-24 text-xs font-bold text-error md:max-w-40"
+          >
+            Please choose an answer
+          </span>
+        }
+      </div>
     </div>
   }
 </div>

--- a/src/app/shared/ui-kit/ui-question-card/ui-question-card.component.html
+++ b/src/app/shared/ui-kit/ui-question-card/ui-question-card.component.html
@@ -19,24 +19,25 @@
     <quiz-ui-spinner></quiz-ui-spinner>
   } @else {
     <div class="space-y-4">
-      <h5 class="text-2xl-plus font-semibold md:text-3xl">
+      <h5 class="text-2xl font-semibold md:text-3xl">
         <p>Let's begin with this</p>
         <span class="bg-error" [innerHTML]="currentQuestion().category"></span>
       </h5>
 
       <form class="flex flex-col items-center">
         <p
-          class="mb-4 text-2xl-plus font-semibold md:text-3xl"
+          class="mb-4 text-2xl font-semibold md:text-3xl"
           [innerHTML]="currentQuestion().question"
         ></p>
         <quiz-ui-radio-group
+          class="self-start md:self-auto"
           [options]="currentQuestion().answers"
           [optionControl]="radioButtonControl"
         ></quiz-ui-radio-group>
       </form>
     </div>
 
-    <div class="flex items-center justify-between">
+    <div class="mt-5 flex items-center justify-between">
       <quiz-ui-button
         class="text-shade"
         [variant]="'ghost'"

--- a/src/app/shared/ui-kit/ui-question-card/ui-question-card.component.ts
+++ b/src/app/shared/ui-kit/ui-question-card/ui-question-card.component.ts
@@ -12,6 +12,7 @@ import { ErrorHandlerService } from '../../../core/services/error-handler.servic
 import { AsyncPipe } from '@angular/common';
 import { UiErrorNotificationComponent } from '../ui-error-notification/ui-error-notification.component';
 import { DialogService } from '../../../core/services/dialog.service';
+import { Subscription } from 'rxjs';
 
 @Component({
   selector: 'quiz-ui-question-card',
@@ -33,6 +34,8 @@ export class UiQuestionCardComponent implements OnInit {
   private readonly questionsService = inject(QuestionsService);
   private readonly errorHandlerService = inject(ErrorHandlerService);
   private readonly dialogService = inject(DialogService);
+
+  private subscription: Subscription;
 
   private quizId!: number;
   numberOfQuestions!: number;
@@ -59,10 +62,13 @@ export class UiQuestionCardComponent implements OnInit {
     this.numberOfQuestions = +this.route.snapshot.paramMap.get('questions')!;
 
     this.loadQuestion();
+    this.resetStepMessage();
+  }
 
-    this.radioButtonControl.valueChanges.subscribe(() => {
-      this.isMessageVisible = false;
-    });
+  ngOnDestroy() {
+    if (this.subscription) {
+      this.subscription.unsubscribe();
+    }
   }
 
   loadQuestion(): void {
@@ -123,5 +129,11 @@ export class UiQuestionCardComponent implements OnInit {
     } else {
       this.radioButtonControl.reset();
     }
+  }
+
+  private resetStepMessage(): void {
+    this.subscription = this.radioButtonControl.valueChanges.subscribe(() => {
+      this.isMessageVisible = false;
+    });
   }
 }

--- a/src/app/shared/ui-kit/ui-question-card/ui-question-card.component.ts
+++ b/src/app/shared/ui-kit/ui-question-card/ui-question-card.component.ts
@@ -65,7 +65,7 @@ export class UiQuestionCardComponent implements OnInit {
     this.resetStepMessage();
   }
 
-  ngOnDestroy() {
+  ngOnDestroy(): void {
     if (this.subscription) {
       this.subscription.unsubscribe();
     }

--- a/src/app/shared/ui-kit/ui-question-card/ui-question-card.component.ts
+++ b/src/app/shared/ui-kit/ui-question-card/ui-question-card.component.ts
@@ -29,7 +29,6 @@ import { DialogService } from '../../../core/services/dialog.service';
 })
 export class UiQuestionCardComponent implements OnInit {
   private readonly router = inject(Router);
-
   private readonly route = inject(ActivatedRoute);
   private readonly questionsService = inject(QuestionsService);
   private readonly errorHandlerService = inject(ErrorHandlerService);
@@ -37,6 +36,7 @@ export class UiQuestionCardComponent implements OnInit {
 
   private quizId!: number;
   numberOfQuestions!: number;
+  isMessageVisible = false;
   avatarPath = AVATAR_PATHS.PROFILE_1;
   errorMessage$ = this.errorHandlerService.getErrorMessage$();
   questions = signal<Question[]>([]);
@@ -59,6 +59,10 @@ export class UiQuestionCardComponent implements OnInit {
     this.numberOfQuestions = +this.route.snapshot.paramMap.get('questions')!;
 
     this.loadQuestion();
+
+    this.radioButtonControl.valueChanges.subscribe(() => {
+      this.isMessageVisible = false;
+    });
   }
 
   loadQuestion(): void {
@@ -72,9 +76,13 @@ export class UiQuestionCardComponent implements OnInit {
   }
 
   nextQuestion(): void {
-    this.saveCurrentAnswer();
-    this.currentQuestionIndex.update(index => index + 1);
-    this.restorePreviousAnswer();
+    if (this.radioButtonControl.valid) {
+      this.saveCurrentAnswer();
+      this.currentQuestionIndex.update(index => index + 1);
+      this.restorePreviousAnswer();
+    } else {
+      this.isMessageVisible = true;
+    }
   }
 
   previousQuestion(): void {
@@ -85,9 +93,12 @@ export class UiQuestionCardComponent implements OnInit {
   }
 
   finishQuiz(): void {
-    this.dialogService.setQuizFinished(true);
-
-    this.router.navigate(['/statistics']);
+    if (this.radioButtonControl.valid) {
+      this.dialogService.setQuizFinished(true);
+      this.router.navigate(['/statistics']);
+    } else {
+      this.isMessageVisible = true;
+    }
   }
 
   private saveCurrentAnswer(): void {

--- a/src/app/shared/ui-kit/ui-question-card/ui-question-card.component.ts
+++ b/src/app/shared/ui-kit/ui-question-card/ui-question-card.component.ts
@@ -35,7 +35,7 @@ export class UiQuestionCardComponent implements OnInit {
   private readonly errorHandlerService = inject(ErrorHandlerService);
   private readonly dialogService = inject(DialogService);
 
-  private subscription: Subscription;
+  private subscription!: Subscription;
 
   private quizId!: number;
   numberOfQuestions!: number;

--- a/src/app/shared/ui-kit/ui-radio-group/ui-radio-group.component.html
+++ b/src/app/shared/ui-kit/ui-radio-group/ui-radio-group.component.html
@@ -1,7 +1,7 @@
 @for (option of options(); track option) {
   <label
     [for]="option"
-    class="mb-2 flex cursor-pointer items-center gap-2 font-semibold text-primary"
+    class="mb-2 flex cursor-pointer items-center justify-start gap-2 font-semibold text-primary"
   >
     <input
       [id]="option"
@@ -9,11 +9,14 @@
       [formControl]="optionControl()"
       [value]="option"
       name="option"
-      class="peer flex h-6 w-6 appearance-none items-center justify-center rounded-full border-2 border-shade bg-bright checked:border-error checked:bg-bright"
+      class="peer flex h-6 w-6 min-w-6 appearance-none items-center justify-center rounded-full border-2 border-shade bg-bright checked:border-error checked:bg-bright"
     />
     <div
-      class="absolute ml-[6px] h-3 w-3 rounded-full bg-bright peer-checked:bg-error"
+      class="absolute m-[6px] h-3 w-3 rounded-full bg-bright peer-checked:bg-error"
     ></div>
-    <span class="peer-checked:text-bright" [innerHTML]="option"></span>
+    <span
+      class="max-w-full break-words text-left peer-checked:text-bright"
+      [innerHTML]="option"
+    ></span>
   </label>
 }


### PR DESCRIPTION
## Links

[Trello ticket 1](https://trello.com/c/9Vv7otPx/26-delete-simulate-error-button-and-alert-for-play-button-on-home-page)
[Trello ticket 2](https://trello.com/c/4nsuEdhW/25-improve-quiz-page-style)
[App](https://quiz-app-nerdysoft--pr26-fix-fix-demo3-style-k0klau52.web.app/)
## Problem

- The "Let's play" button still had a click event that was no longer needed.
- The simulate error button was present but useless.
- The home item style in the navigation panel wasn't consistent with the design.
- The radio group style needed some improvements for better visual appeal.
- The next/finish button lacked a descriptive text message.

## Solution

- Removed the unnecessary click event from the "Let's play" button.
- Deleted the simulate error button, as it was no longer required.
- Fixed the style for the home item in the navigation panel to align with the design guidelines.
- Enhanced the style of the radio group for a more polished user interface.
- Added a text message to the next/finish button to improve its clarity for the user.
- Made Prev button more visible
