### PR TITLE
Feature/add dialog window for reloading quiz page

### DIFF
--- a/src/app/core/services/dialog.service.ts
+++ b/src/app/core/services/dialog.service.ts
@@ -1,18 +1,26 @@
 import { Injectable } from '@angular/core';
-import { Subject } from 'rxjs';
+import { Observable, Subject } from 'rxjs';
+import { DialogState } from '../../shared/ui-kit/ui-navigation-confirm-dialog/dialog-state.interface';
+import { defaultDialog } from '../../shared/constants/dialog-states';
 
 @Injectable({
   providedIn: 'root',
 })
 export class DialogService {
   private canLeavePageStatus = false;
-  private openDialogSubject = new Subject<void>();
+  private openDialogSubject = new Subject<DialogState>();
+  private statusSubject = new Subject<boolean>();
+  private dialogState: DialogState = defaultDialog;
 
-  status$ = new Subject<boolean>();
-  openDialog$ = this.openDialogSubject.asObservable();
+  status$: Observable<boolean> = this.statusSubject.asObservable();
+  openDialog$: Observable<DialogState> = this.openDialogSubject.asObservable();
 
   setCanPageLeaveStatus(status: boolean): void {
     this.canLeavePageStatus = status;
+  }
+
+  setDialogState(state: DialogState): void {
+    this.dialogState = state;
   }
 
   canLeavePage(): boolean {
@@ -20,10 +28,18 @@ export class DialogService {
   }
 
   openConfirmDialog(): void {
-    this.openDialogSubject.next();
+    this.openDialogSubject.next({
+      ...this.dialogState,
+      isOpen: true,
+    });
   }
 
   setStatus(status: boolean): void {
-    this.status$.next(status);
+    this.statusSubject.next(status);
+  }
+
+  resetDialog(): void {
+    this.canLeavePageStatus = false;
+    this.statusSubject = new Subject<boolean>();
   }
 }

--- a/src/app/core/services/dialog.service.ts
+++ b/src/app/core/services/dialog.service.ts
@@ -5,18 +5,18 @@ import { Subject } from 'rxjs';
   providedIn: 'root',
 })
 export class DialogService {
-  private quizFinishedStatus = false;
+  private canLeavePageStatus = false;
   private openDialogSubject = new Subject<void>();
 
   status$ = new Subject<boolean>();
   openDialog$ = this.openDialogSubject.asObservable();
 
-  setQuizFinished(status: boolean): void {
-    this.quizFinishedStatus = status;
+  setCanPageLeaveStatus(status: boolean): void {
+    this.canLeavePageStatus = status;
   }
 
-  isQuizFinished(): boolean {
-    return this.quizFinishedStatus;
+  canLeavePage(): boolean {
+    return this.canLeavePageStatus;
   }
 
   openConfirmDialog(): void {

--- a/src/app/pages/quiz/quiz-page.guard.ts
+++ b/src/app/pages/quiz/quiz-page.guard.ts
@@ -1,6 +1,6 @@
 import { inject, Injectable } from '@angular/core';
 import { CanDeactivate } from '@angular/router';
-import { filter, first, Observable, of } from 'rxjs';
+import { filter, first, Observable } from 'rxjs';
 import { QuizComponent } from './quiz.component';
 import { DialogService } from '../../core/services/dialog.service';
 
@@ -8,15 +8,18 @@ import { DialogService } from '../../core/services/dialog.service';
   providedIn: 'root',
 })
 export class QuizPageGuard implements CanDeactivate<QuizComponent> {
-  dialogService = inject(DialogService);
+  private dialogService = inject(DialogService);
 
-  canDeactivate(): Observable<boolean> {
+  canDeactivate(): Observable<boolean> | boolean {
     if (this.dialogService.canLeavePage()) {
-      return of(true);
+      return true;
     }
 
-    this.dialogService.openConfirmDialog();
+    return this.openConfirmationDialog();
+  }
 
+  private openConfirmationDialog(): Observable<boolean> {
+    this.dialogService.openConfirmDialog();
     return this.dialogService.status$.pipe(
       filter(status => status !== null),
       first(),

--- a/src/app/pages/quiz/quiz-page.guard.ts
+++ b/src/app/pages/quiz/quiz-page.guard.ts
@@ -11,7 +11,7 @@ export class QuizPageGuard implements CanDeactivate<QuizComponent> {
   dialogService = inject(DialogService);
 
   canDeactivate(): Observable<boolean> {
-    if (this.dialogService.isQuizFinished()) {
+    if (this.dialogService.canLeavePage()) {
       return of(true);
     }
 

--- a/src/app/shared/constants/dialog-states.ts
+++ b/src/app/shared/constants/dialog-states.ts
@@ -8,15 +8,6 @@ export const finishQuizDialog: DialogState = {
   confirmText: 'Finish',
 };
 
-export const reloadPageDialog: DialogState = {
-  isOpen: false,
-  title: 'Reload Page',
-  message:
-    'Are you sure you want to reload the page? Your answers will not be saved.',
-  cancelText: 'Stay',
-  confirmText: 'Reload',
-};
-
 export const defaultDialog: DialogState = {
   isOpen: false,
   title: 'Cancel quiz',

--- a/src/app/shared/constants/dialog-states.ts
+++ b/src/app/shared/constants/dialog-states.ts
@@ -1,0 +1,27 @@
+import { DialogState } from '../ui-kit/ui-navigation-confirm-dialog/dialog-state.interface';
+
+export const finishQuizDialog: DialogState = {
+  isOpen: false,
+  title: 'Finish Quiz',
+  message: 'Are you sure you want to finish the quiz?',
+  cancelText: 'Back to quiz',
+  confirmText: 'Finish',
+};
+
+export const reloadPageDialog: DialogState = {
+  isOpen: false,
+  title: 'Reload Page',
+  message:
+    'Are you sure you want to reload the page? Your answers will not be saved.',
+  cancelText: 'Stay',
+  confirmText: 'Reload',
+};
+
+export const defaultDialog: DialogState = {
+  isOpen: false,
+  title: 'Cancel quiz',
+  message:
+    'Are you sure you want to exit and cancel the quiz? Your answers will not be saved.',
+  cancelText: 'Back to quiz',
+  confirmText: 'Leave page',
+};

--- a/src/app/shared/ui-kit/ui-navigation-confirm-dialog/dialog-state.interface.ts
+++ b/src/app/shared/ui-kit/ui-navigation-confirm-dialog/dialog-state.interface.ts
@@ -1,0 +1,7 @@
+export interface DialogState {
+  isOpen: boolean;
+  title: string;
+  message: string;
+  cancelText: string;
+  confirmText: string;
+}

--- a/src/app/shared/ui-kit/ui-navigation-confirm-dialog/ui-navigation-confirm-dialog.component.html
+++ b/src/app/shared/ui-kit/ui-navigation-confirm-dialog/ui-navigation-confirm-dialog.component.html
@@ -1,14 +1,13 @@
-@if (isDialogOpen) {
+@if (dialogState.isOpen) {
   <div
     class="fixed inset-0 z-50 flex items-center justify-center bg-black bg-opacity-50"
   >
     <div
       class="flex w-80 flex-col items-center justify-center space-y-8 rounded-2xl bg-bright p-10 text-purple-950 md:w-[680px]"
     >
-      <h4 class="text-4xl font-semibold">Cancel quiz</h4>
+      <h4 class="text-4xl font-semibold">{{ dialogState.title }}</h4>
       <p class="text-2xl">
-        Are you sure you want to exit and cancel the quiz? Your answers will not
-        be saved.
+        {{ dialogState.message }}
       </p>
       <div class="flex flex-wrap items-center justify-center gap-4">
         <quiz-ui-button
@@ -16,13 +15,13 @@
           [size]="'medium'"
           [variant]="'ghost'"
           (buttonClick)="onCancel()"
-          >Back to quiz</quiz-ui-button
+          >{{ dialogState.cancelText }}</quiz-ui-button
         >
         <quiz-ui-button
           size="medium"
           [variant]="'accent'"
           (buttonClick)="onConfirm()"
-          >Go on main page</quiz-ui-button
+          >{{ dialogState.confirmText }}</quiz-ui-button
         >
       </div>
     </div>

--- a/src/app/shared/ui-kit/ui-navigation-confirm-dialog/ui-navigation-confirm-dialog.component.ts
+++ b/src/app/shared/ui-kit/ui-navigation-confirm-dialog/ui-navigation-confirm-dialog.component.ts
@@ -2,6 +2,7 @@ import { Component, inject } from '@angular/core';
 import { UiButtonComponent } from '../ui-button/ui-button.component';
 import { DialogService } from '../../../core/services/dialog.service';
 import { Subscription } from 'rxjs';
+import { DialogState } from './dialog-state.interface';
 
 @Component({
   selector: 'quiz-ui-navigation-confirm-dialog',
@@ -11,17 +12,20 @@ import { Subscription } from 'rxjs';
 })
 export class NavigationConfirmDialogComponent {
   dialogService = inject(DialogService);
-  isDialogOpen = false;
+  dialogState: DialogState = {
+    isOpen: false,
+    title: '',
+    message: '',
+    cancelText: '',
+    confirmText: '',
+  };
+
   private subscription!: Subscription;
 
   ngOnInit(): void {
-    this.subscription = this.dialogService.openDialog$.subscribe(() => {
-      this.open();
+    this.subscription = this.dialogService.openDialog$.subscribe((state) => {
+      this.dialogState = state;
     });
-  }
-
-  open(): void {
-    this.isDialogOpen = true;
   }
 
   onConfirm(): void {
@@ -35,6 +39,13 @@ export class NavigationConfirmDialogComponent {
   }
 
   private closeDialog(): void {
-    this.isDialogOpen = false;
+    this.dialogState = {
+      ...this.dialogState,
+      isOpen: false,
+    };
+  }
+
+  ngOnDestroy(): void {
+    this.subscription?.unsubscribe();
   }
 }

--- a/src/app/shared/ui-kit/ui-question-card/ui-question-card.component.ts
+++ b/src/app/shared/ui-kit/ui-question-card/ui-question-card.component.ts
@@ -149,6 +149,7 @@ export class UiQuestionCardComponent implements OnInit {
     if (this.subscription) {
       this.subscription.unsubscribe();
     }
+
     window.removeEventListener('beforeunload', this.handleBeforeUnload);
   }
 }

--- a/src/app/shared/ui-kit/ui-question-card/ui-question-card.component.ts
+++ b/src/app/shared/ui-kit/ui-question-card/ui-question-card.component.ts
@@ -63,6 +63,7 @@ export class UiQuestionCardComponent implements OnInit {
 
     this.loadQuestion();
     this.resetStepMessage();
+    this.dialogService.setCanPageLeaveStatus(false);
   }
 
   ngOnDestroy(): void {
@@ -100,7 +101,7 @@ export class UiQuestionCardComponent implements OnInit {
 
   finishQuiz(): void {
     if (this.radioButtonControl.valid) {
-      this.dialogService.setQuizFinished(true);
+      this.dialogService.setCanPageLeaveStatus(true);
       this.router.navigate(['/statistics']);
     } else {
       this.isMessageVisible = true;

--- a/src/app/shared/ui-kit/ui-question-card/ui-question-card.component.ts
+++ b/src/app/shared/ui-kit/ui-question-card/ui-question-card.component.ts
@@ -73,14 +73,6 @@ export class UiQuestionCardComponent implements OnInit {
 
   private handleBeforeUnload = (event: BeforeUnloadEvent): void => {
     if (!this.dialogService.canLeavePage()) {
-      // this.dialogService.setDialogState(reloadPageDialog);
-      // this.dialogService.openConfirmDialog();
-
-      // this.dialogService.status$.pipe(first()).subscribe((status) => {
-      //   if (status) {
-      //     window.location.reload();
-      //   }
-      // });
       event.preventDefault();
     }
   };

--- a/src/environments/environment.prod.ts
+++ b/src/environments/environment.prod.ts
@@ -2,8 +2,8 @@ export const environment = {
   production: true,
   categoriesUrl: 'https://opentdb.com/api_category.php',
   numberOfQuizCategories: 10,
-  minNumberOfQuestion: 8,
-  maxNumberOfQuestion: 15,
+  minNumberOfQuestion: 2,
+  maxNumberOfQuestion: 4,
   categoriesApiErrorMessage:
     'Can not load categories right now. Please reload the page.',
 };

--- a/src/environments/environment.ts
+++ b/src/environments/environment.ts
@@ -3,7 +3,7 @@ export const environment = {
   categoriesUrl: 'https://opentdb.com/api_category.php',
   questionUrl: 'https://opentdb.com/api.php',
   numberOfQuizCategories: 10,
-  minNumberOfQuestion: 8,
-  maxNumberOfQuestion: 15,
+  minNumberOfQuestion: 2,
+  maxNumberOfQuestion: 4,
   apiErrorMessage: 'Can not load data right now. Please try again later.',
 };


### PR DESCRIPTION
## Links

[Trello](https://trello.com/c/m25mAgh4/27-improve-quiz-page-guard-and-dialog-window)
[App](https://quiz-app-nerdysoft--pr27-feature-add-dialog-w-sbu4k84w.web.app/)
## Problem

- Unnecessary dialog interruptions: Users are blocked from navigating away even when no answer is selected.
- Loss of progress on refresh: Page refresh risks losing user progress without warning.
- Add confirm dialog for last question: Current dialog don't have customization for the last question.

## Solution

- Allow navigation when no answer is selected.
- Confirmation on refresh: Introduced a confirmation dialog triggered on page refresh to prevent progress loss.
- Custom dialog for last question: Added a message for the last question, which guides users to complete the quiz and proceed to the statistics page.