### PR TITLE
Feature/improve style mobile version

### DIFF
--- a/src/app/pages/catalog/components/quiz-card/quiz-card.component.html
+++ b/src/app/pages/catalog/components/quiz-card/quiz-card.component.html
@@ -1,4 +1,7 @@
-<div class="h-60 w-64 rounded-xl p-4 shadow-xl {{ styles.backgroundColor }}">
+<div
+  [routerLink]="categoryUrlRoute"
+  class="h-60 w-64 rounded-xl p-4 shadow-xl {{ styles.backgroundColor }}"
+>
   <div class="flex items-center justify-between">
     <p class="{{ styles.textColor }}">
       {{ quizCategory()?.numberOfQuestion }} Questions

--- a/src/app/pages/statistics/statistics.component.html
+++ b/src/app/pages/statistics/statistics.component.html
@@ -1,12 +1,12 @@
-<div class="flex flex-col items-center justify-center gap-5 p-7">
+<div class="flex flex-col items-center justify-center gap-5 md:p-7">
   <quiz-ui-quiz-feedback [lastQuizData]="lastQuizData"></quiz-ui-quiz-feedback>
 
   <div
-    class="flex flex-col items-center justify-center rounded-3xl bg-bright p-7"
+    class="flex w-full max-w-xl flex-col items-center justify-center rounded-3xl bg-bright p-7"
   >
     <p class="mb-5 text-3xl font-bold text-primary">My statistics</p>
 
-    <div class="grid max-w-md grid-cols-2 gap-3 text-sm text-primary">
+    <div class="grid grid-cols-2 gap-3 text-sm text-primary">
       <p class="font-semibold">Quizzes Completed:</p>
       <p>{{ userStatistic().numberOfQuizzes }}</p>
 

--- a/src/app/shared/ui-kit/ui-donut-chart/ui-donut-chart.component.html
+++ b/src/app/shared/ui-kit/ui-donut-chart/ui-donut-chart.component.html
@@ -1,4 +1,4 @@
-<div class="flex items-center gap-5">
+<div class="flex flex-wrap items-center justify-center gap-5">
   <ngx-charts-pie-chart
     [results]="donutData"
     [animations]="true"

--- a/src/app/shared/ui-kit/ui-header/ui-header.component.html
+++ b/src/app/shared/ui-kit/ui-header/ui-header.component.html
@@ -50,7 +50,7 @@
     [class.-translate-y-full]="!isMenuOpen()"
     [class.translate-y-0]="isMenuOpen()"
   >
-    <div class="flex flex-col">
+    <div class="float-end flex flex-col">
       <ul class="flex flex-col">
         @for (item of navItems; track $index) {
           <li>
@@ -64,7 +64,7 @@
           </li>
         }
       </ul>
-      <div class="flex items-center">
+      <div class="mt-10 flex items-center">
         <quiz-ui-button variant="accent"> Login </quiz-ui-button>
       </div>
     </div>

--- a/src/app/shared/ui-kit/ui-quiz-feedback/ui-quiz-feedback.component.html
+++ b/src/app/shared/ui-kit/ui-quiz-feedback/ui-quiz-feedback.component.html
@@ -15,7 +15,7 @@
   <h6 class="text-2xl font-semibold">
     {{ lastQuizData().time | timeFormat }}
   </h6>
-  <p class="w-1/2 text-center">
+  <p class="text-center md:max-w-xl">
     {{ getFeedbackMessage() }}
   </p>
 </div>


### PR DESCRIPTION
## Links

<!--- Add any relevant tickets, docs, or screenshots -->

## Problem

- The quiz card on the catalog page is not clickable
- The mobile menu and statistics page require style improvements to enhance alignment, spacing, and overall visual consistency.

## Solution

- Made the quiz card on the catalog page clickable, allowing users to navigate to the corresponding quiz via the proper route.
- Moved mobile menu items to the right for better alignment.
- Set the statistics card width to 100% for improved mobile responsiveness.
- Enabled chart legend wrapping on small devices to prevent overflow issues.
- Applied minor style improvements to the statistics page for better usability.
